### PR TITLE
Clarify that you might need -Dusemultiplicity

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,8 @@ you have to build it as:
 
     perlbrew install perl-5.20.0 -Duseshrplib
 
+(or, if you want to use more than one Inline::Perl5 interpeter safely, for instance from within Perl 6 threads, add the `-Dusemultiplicity` option as well)
+
 and then build Inline::Perl5 with
 
     make


### PR DESCRIPTION
If you want to play with interpreter pools or anything like that, you need to be able to create a re-entrant-safe version of libperl. This option is leveraged by the likes of nginx/uwsgi, so it seems to be one of the "safe options" you can enable in Perl 5.