### PR TITLE
Detect perls not configured with a shared library

### DIFF
--- a/Build.pm
+++ b/Build.pm
@@ -12,6 +12,9 @@ class Build is Panda::Builder {
         shell('perl -MFilter::Simple -e ""')
             or die "\nPlease install the Filter::Simple Perl 5 module!\n";
 
+        shell(q{perl -MConfig -e '$Config{config_args} =~ /-Duseshrplib/ || exit 1'})
+            or die "\nYour perl was not configured to build a shared library; unable to build\n";
+
         my Str $blib = "$dir/blib";
         rm_f("$dir/lib/Inline/p5helper.so");
         rm_rf($blib);


### PR DESCRIPTION
Inline::Perl5 can only work if perl was configured with useshrplib; if
a perl without this configuration option is used, the user gets a host
of compiler errors that they may or may not understand.  Bailing out
early in the build process tells the user exactly what is going on,
and what they need to do to fix it.