### PR TITLE
Not all control exceptions are warnings.

### DIFF
--- a/lib/Inline/Perl5.pm6
+++ b/lib/Inline/Perl5.pm6
@@ -524,15 +524,19 @@ class Perl6Callbacks {
     method run($code) {
         return EVAL $code;
         CONTROL {
-            note $_.gist;
-            $_.resume;
+            when CX::Warn {
+                note $_.gist;
+                $_.resume;
+            }
         }
     }
     method call(Str $name, @args) {
         return &::($name)(|@args);
         CONTROL {
-            note $_.gist;
-            $_.resume;
+            when CX::Warn {
+                note $_.gist;
+                $_.resume;
+            }
         }
     }
     method invoke(Str $package, Str $name, @args) {
@@ -541,8 +545,10 @@ class Perl6Callbacks {
         %named<True> //= [];
         return ::($package)."$name"(|%named<False>, |%(%named<True>));
         CONTROL {
-            note $_.gist;
-            $_.resume;
+            when CX::Warn {
+                note $_.gist;
+                $_.resume;
+            }
         }
     }
     method create_pair(Any $key, Mu $value) {
@@ -919,8 +925,10 @@ method BUILD(*%args) {
         my @retvals = $p6obj."$name"(|self.p5_array_to_p6_array($args));
         return self.p6_to_p5(@retvals);
         CONTROL {
-            note $_.gist;
-            $_.resume;
+            when CX::Warn {
+                note $_.gist;
+                $_.resume;
+            }
         }
         CATCH {
             default {
@@ -936,8 +944,10 @@ method BUILD(*%args) {
         my @retvals = $callable(|self.p5_array_to_p6_array($args));
         return self.p6_to_p5(@retvals);
         CONTROL {
-            note $_.gist;
-            $_.resume;
+            when CX::Warn {
+                note $_.gist;
+                $_.resume;
+            }
         }
         CATCH {
             default {


### PR DESCRIPTION
This was potentially a problem before, and is certainly one now that
return is done as a control exception too.