### PR TITLE
Bug #65 solution

### DIFF
--- a/lib/Inline/Perl5.pm6
+++ b/lib/Inline/Perl5.pm6
@@ -915,7 +915,7 @@ method BUILD(*%args) {
     }
     else {
         my @args = @*ARGS;
-        $!p5 = p5_init_perl(@args.elems + 3, CArray[Str].new('', '-e', '0', |@args));
+        $!p5 = p5_init_perl(@args.elems + 4, CArray[Str].new('', '-e', '0', '--', |@args));
     }
     X::Inline::Perl5::NoMultiplicity.new.throw unless $!p5.defined;
 


### PR DESCRIPTION
I think, the change solve bug #65. Test argv.t is success. Switches for Perl 5 one-liner must be written behind '--'.