### PR TITLE
Extract the interpreter bindings

### DIFF
--- a/lib/Inline/Language/ObjectKeeper.pm6
+++ b/lib/Inline/Language/ObjectKeeper.pm6
@@ -1,0 +1,27 @@
+class Inline::Language::ObjectKeeper {
+    has @!objects;
+    has $!last_free = -1;
+
+    method keep(Any:D $value) returns Int {
+        if $!last_free != -1 {
+            my $index = $!last_free;
+            $!last_free = @!objects[$!last_free];
+            @!objects[$index] = $value;
+            return $index;
+        }
+        else {
+            @!objects.push($value);
+            return @!objects.end;
+        }
+    }
+
+    method get(Int $index) returns Any:D {
+        @!objects[$index];
+    }
+
+    method free(Int $index) {
+        @!objects[$index] = $!last_free;
+        $!last_free = $index;
+    }
+}
+

--- a/lib/Inline/Perl5/Array.pm6
+++ b/lib/Inline/Perl5/Array.pm6
@@ -1,0 +1,67 @@
+use NativeCall;
+use Inline::Perl5::Interpreter;
+
+class Inline::Perl5::Array does Iterable does Positional {
+    has $!ip5; # Had to remove the Inline::Perl5 type to prevent circular dep
+    has Inline::Perl5::Interpreter $!p5;
+    has Pointer $.av;
+    method new(:$ip5, :$p5, :$av) {
+        my \arr = self.CREATE;
+        arr.BUILD(:$ip5, :$p5, :$av);
+        arr
+    }
+    submethod BUILD(:$!ip5, :$!p5, :$!av) {
+    }
+    submethod DESTROY() {
+        $!ip5.sv_refcnt_dec($!av);
+    }
+    method ASSIGN-POS(Inline::Perl5::Array:D: Int() \pos, Mu \assignval) is raw {
+        $!p5.p5_av_store($!av, pos, $!ip5.p6_to_p5(assignval));
+        assignval
+    }
+    method AT-POS(Inline::Perl5::Array:D: Int() \pos) is raw {
+        $!ip5.p5_to_p6($!p5.p5_av_fetch($!av, pos))
+    }
+    method EXISTS-POS(Inline::Perl5::Array:D: Int() \pos) {
+        0 <= pos <= $!p5.p5_av_top_index($!av)
+    }
+    method Array() {
+        my int32 $av_len = $!p5.p5_av_top_index($!av);
+
+        my $arr = [];
+        loop (my int32 $i = 0; $i <= $av_len; $i = $i + 1) {
+            $arr.push($!ip5.p5_to_p6($!p5.p5_av_fetch($!av, $i)));
+        }
+        $arr
+    }
+    method iterator() {
+        self.Array.iterator
+    }
+    method list() {
+        self.Array.list
+    }
+    method pairs() {
+        self.Array.pairs
+    }
+    method kv() {
+        self.Array.kv
+    }
+    method elems() {
+        $!p5.p5_av_top_index($!av) + 1
+    }
+    method Numeric() {
+        self.elems
+    }
+    method Bool() {
+        ?($!p5.p5_av_top_index($!av) + 1);
+    }
+    multi method gist(Inline::Perl5::Array:D:) {
+        self.Array.gist
+    }
+    multi method perl(Inline::Perl5::Array:D:) {
+        self.Array.perl
+    }
+    multi method Str(Inline::Perl5::Array:D:) {
+        self.Array.Str
+    }
+}

--- a/lib/Inline/Perl5/Callable.pm6
+++ b/lib/Inline/Perl5/Callable.pm6
@@ -1,0 +1,16 @@
+use NativeCall;
+
+class Inline::Perl5::Callable does Callable {
+    has Pointer $.ptr;
+    has $.perl5; # Inline::Perl5 is circular
+
+    method CALL-ME(*@args) {
+        $.perl5.execute($.ptr, @args);
+    }
+
+    submethod DESTROY {
+        $!perl5.sv_refcnt_dec($!ptr) if $!ptr;
+        $!ptr = Pointer;
+    }
+}
+

--- a/lib/Inline/Perl5/Hash.pm6
+++ b/lib/Inline/Perl5/Hash.pm6
@@ -1,0 +1,101 @@
+use NativeCall;
+use Inline::Perl5::Interpreter;
+
+class Inline::Perl5::Hash does Iterable does Associative {
+    has $!ip5; # Inline::Perl5 type removed to avoid circle
+    has Inline::Perl5::Interpreter $!p5;
+    has Pointer $.hv;
+    method new(:$ip5, :$p5, :$hv) {
+        my \hash = self.CREATE;
+        hash.BUILD(:$ip5, :$p5, :$hv);
+        hash
+    }
+    submethod BUILD(:$!ip5, :$!p5, :$!hv) {
+        $!p5.p5_sv_refcnt_inc($!hv);
+    }
+    submethod DESTROY() {
+        $!ip5.sv_refcnt_dec($!hv);
+    }
+    method ASSIGN-KEY(Inline::Perl5::Hash:D: Str() \key, Mu \assignval) is raw {
+        $!p5.p5_hv_store($!hv, key, $!ip5.p6_to_p5(assignval));
+        assignval
+    }
+    method AT-KEY(Inline::Perl5::Hash:D: Str() \key) is raw {
+        my $buf = key.encode('UTF-8');
+        $!ip5.p5_to_p6($!p5.p5_hv_fetch($!hv, $buf.elems, $buf))
+    }
+    method EXISTS-KEY(Inline::Perl5::Hash:D: Str() \key) {
+        my $buf = key.encode('UTF-8');
+        $!p5.p5_hv_exists($!hv, $buf.elems, $buf)
+    }
+    method Hash() {
+        my int32 $len = $!p5.p5_hv_iterinit($!hv);
+
+        my $hash = {};
+
+        for 0 .. $len - 1 {
+            my Pointer $next = $!p5.p5_hv_iternext($!hv);
+            my Pointer $key = $!p5.p5_hv_iterkeysv($next);
+            die 'Hash entry without key!?' unless $key;
+            my Str $p6_key = $!p5.p5_sv_to_char_star($key);
+            my $val = $!ip5.p5_to_p6($!p5.p5_hv_iterval($!hv, $next));
+            $hash{$p6_key} = $val;
+        }
+
+        $hash
+    }
+    method iterator() {
+        self.Hash.iterator
+    }
+    method list() {
+        self.Hash.list
+    }
+    method keys() {
+        self.Hash.keys
+    }
+    method values() {
+        self.Hash.values
+    }
+    method pairs() {
+        self.Hash.pairs
+    }
+    method antipairs() {
+        self.Hash.antipairs
+    }
+    method invert() {
+        self.Hash.invert
+    }
+    method kv() {
+        self.Hash.kv
+    }
+    method elems() {
+        self.Hash.elems
+    }
+    method Int() {
+        self.elems
+    }
+    method Numeric() {
+        self.elems
+    }
+    method Bool() {
+        self.Hash.Bool
+    }
+    method Capture() {
+        self.Hash.Capture
+    }
+    method push(*@new) {
+        self.Hash.push(|@new)
+    }
+    method append(+@values) {
+        self.Hash.append(|@values)
+    }
+    multi method gist(Inline::Perl5::Hash:D:) {
+        self.Hash.gist
+    }
+    multi method perl(Inline::Perl5::Hash:D:) {
+        self.Hash.perl
+    }
+    multi method Str(Inline::Perl5::Hash:D:) {
+        self.Hash.Str
+    }
+}

--- a/lib/Inline/Perl5/Interpreter.pm6
+++ b/lib/Inline/Perl5/Interpreter.pm6
@@ -1,0 +1,226 @@
+class Inline::Perl5::Interpreter is repr('CPointer') {
+    use NativeCall;
+
+    my constant $p5helper = %?RESOURCES<libraries/p5helper>.Str;
+
+    our sub p5_size_of_iv() is native($p5helper)
+        returns size_t { ... }
+
+    our sub p5_size_of_nv() is native($p5helper)
+        returns size_t { ... }
+
+    BEGIN my constant IV = p5_size_of_iv() == 8 ?? int64 !! int32;
+    BEGIN my constant NVSIZE = p5_size_of_nv();
+    BEGIN die "Cannot support { NVSIZE * 8 } bit NVs yet." if NVSIZE != 4|8;
+    BEGIN my constant NV = NVSIZE == 8 ?? num64 !! num32;
+
+    our sub p5_init_perl(
+        uint32,
+        CArray[Str],
+        &call_method (IV, Str, int32, Pointer, Pointer --> Pointer),
+        &call (IV, Pointer, Pointer --> Pointer),
+        &free_p6_object (IV),
+        &hash_at_key (IV, Str --> Pointer),
+        &hash_assign_key (IV, Str, Pointer),
+    ) is native($p5helper)
+        returns Inline::Perl5::Interpreter { ... }
+
+    our sub p5_init_callbacks(
+        &call_method (IV, Str, int32, Pointer, Pointer --> Pointer),
+        &call (IV, Pointer, Pointer --> Pointer),
+        &free_p6_object (IV),
+        &hash_at_key (IV, Str --> Pointer),
+        &hash_assign_key (IV, Str, Pointer),
+    ) is native($p5helper)
+        { ... }
+
+    our sub p5_terminate() is native($p5helper)
+        { ... }
+
+    method p5_inline_perl6_xs_init() is native($p5helper)
+        { ... }
+
+    method p5_SvIOK(Pointer) is native($p5helper)
+        returns uint32 { ... }
+
+    method p5_SvNOK(Pointer) is native($p5helper)
+        returns uint32 { ... }
+
+    method p5_SvPOK(Pointer) is native($p5helper)
+        returns uint32 { ... }
+
+    method p5_sv_utf8(Pointer) is native($p5helper)
+        returns uint32 { ... }
+
+    method p5_is_array(Pointer) is native($p5helper)
+        returns int32 { ... }
+
+    method p5_is_hash(Pointer) is native($p5helper)
+        returns int32 { ... }
+
+    method p5_is_scalar_ref(Pointer) is native($p5helper)
+        returns int32 { ... }
+
+    method p5_is_undef(Pointer) is native($p5helper)
+        returns int32 { ... }
+
+    method p5_get_type(Pointer) is native($p5helper)
+        returns int32 { ... }
+
+    method p5_sv_to_buf(Pointer, CArray[CArray[int8]]) is native($p5helper)
+        returns size_t { ... }
+
+    method p5_sv_to_char_star(Pointer) is native($p5helper)
+        returns Str { ... }
+
+    method p5_sv_to_av(Pointer) is native($p5helper)
+        returns Pointer { ... }
+
+    method p5_sv_to_av_inc(Pointer) is native($p5helper)
+        returns Pointer { ... }
+
+    method p5_sv_to_hv(Pointer) is native($p5helper)
+        returns Pointer { ... }
+
+    method p5_sv_refcnt_dec(Pointer) is native($p5helper)
+        { ... }
+
+    method p5_sv_2mortal(Pointer) is native($p5helper)
+        { ... }
+
+    method p5_sv_refcnt_inc(Pointer) is native($p5helper)
+        { ... }
+
+    method p5_int_to_sv(IV) is native($p5helper)
+        returns Pointer { ... }
+
+    method p5_float_to_sv(NV) is native($p5helper)
+        returns Pointer { ... }
+
+    method p5_str_to_sv(size_t, Blob) is native($p5helper)
+        returns Pointer { ... }
+
+    method p5_buf_to_sv(size_t, Blob) is native($p5helper)
+        returns Pointer { ... }
+
+    method p5_sv_to_ref(Pointer) is native($p5helper)
+        returns Pointer { ... }
+
+    method p5_av_top_index(Pointer) is native($p5helper)
+        returns int32 { ... }
+
+    method p5_av_fetch(Pointer, int32) is native($p5helper)
+        returns Pointer { ... }
+
+    method p5_av_store(Pointer, int32, Pointer) is native($p5helper)
+        { ... }
+
+    method p5_av_push(Pointer, Pointer) is native($p5helper)
+        { ... }
+
+    method p5_hv_iterinit(Pointer) is native($p5helper)
+        returns int32 { ... }
+
+    method p5_hv_iternext(Pointer) is native($p5helper)
+        returns Pointer { ... }
+
+    method p5_hv_iterkeysv(Pointer) is native($p5helper)
+        returns Pointer { ... }
+
+    method p5_hv_iterval(Pointer, Pointer) is native($p5helper)
+        returns Pointer { ... }
+
+    method p5_undef() is native($p5helper)
+        returns Pointer { ... }
+
+    method p5_newHV() is native($p5helper)
+        returns Pointer { ... }
+
+    method p5_newAV() is native($p5helper)
+        returns Pointer { ... }
+
+    method p5_newRV_inc(Pointer) is native($p5helper)
+        returns Pointer { ... }
+
+    method p5_newRV_noinc(Pointer) is native($p5helper)
+        returns Pointer { ... }
+
+    method p5_sv_reftype(Pointer) is native($p5helper)
+        returns Str { ... }
+
+    method p5_hv_fetch(Pointer, size_t, Blob) is native($p5helper)
+        returns Pointer { ... }
+
+    method p5_hv_store(Pointer, Str, Pointer) is native($p5helper)
+        { ... }
+
+    method p5_hv_exists(Pointer, size_t, Blob) is native($p5helper)
+        returns int32 { ... }
+
+    method p5_call_function(Str, int32, CArray[Pointer], int32 is rw, int32 is rw, int32 is rw) is native($p5helper)
+        returns Pointer { ... }
+
+    method p5_call_method(Str, Pointer, int32, Str, int32, Pointer, int32 is rw, int32 is rw, int32 is rw) is native($p5helper)
+        returns Pointer { ... }
+
+    method p5_call_package_method(Str, Str, int32, CArray[Pointer], int32 is rw, int32 is rw, int32 is rw) is native($p5helper)
+        returns Pointer { ... }
+
+    method p5_call_code_ref(Pointer, int32, CArray[Pointer], int32 is rw, int32 is rw, int32 is rw) is native($p5helper)
+        returns Pointer { ... }
+
+    method p5_rebless_object(Pointer, Str, IV) is native($p5helper)
+        { ... }
+
+    method p5_destruct_perl() is native($p5helper)
+        { ... }
+
+    method p5_sv_iv(Pointer) is native($p5helper)
+        returns IV { ... }
+
+    method p5_sv_nv(Pointer) is native($p5helper)
+        returns NV { ... }
+
+    method p5_sv_rv(Pointer) is native($p5helper)
+        returns Pointer { ... }
+
+    method p5_is_object(Pointer) is native($p5helper)
+        returns int32 { ... }
+
+    method p5_is_sub_ref(Pointer) is native($p5helper)
+        returns int32 { ... }
+
+    method p5_get_global(Str) is native($p5helper)
+        returns Pointer { ... }
+
+    method p5_eval_pv(Str, int32) is native($p5helper)
+        returns Pointer { ... }
+
+    method p5_err_sv() is native($p5helper)
+        returns Pointer { ... }
+
+    method p5_wrap_p6_object(IV, Pointer) is native($p5helper)
+        returns Pointer { ... }
+
+    method p5_wrap_p6_callable(IV, Pointer) is native($p5helper)
+        returns Pointer { ... }
+
+    method p5_wrap_p6_hash(
+        IV,
+    ) is native($p5helper)
+        returns Pointer { ... }
+
+    method p5_wrap_p6_handle(IV, Pointer) is native($p5helper)
+        returns Pointer { ... }
+
+    method p5_is_wrapped_p6_object(Pointer) is native($p5helper)
+        returns int32 { ... }
+
+    method p5_unwrap_p6_object(Pointer) is native($p5helper)
+        returns IV { ... }
+
+    method p5_unwrap_p6_hash(Pointer) is native($p5helper)
+        returns IV { ... }
+
+}
+

--- a/lib/Inline/Perl5/Object.pm6
+++ b/lib/Inline/Perl5/Object.pm6
@@ -1,0 +1,18 @@
+use NativeCall;
+
+class Inline::Perl5::Object {
+    has Pointer $.ptr is rw;
+    has $.perl5;
+
+    method sink() { self }
+
+    method Str() {
+        my $stringify = $!perl5.call('overload::Method', self, '""');
+        return $stringify ?? $stringify(self) !! callsame;
+    }
+
+    submethod DESTROY {
+        $!perl5.sv_refcnt_dec($!ptr) if $!ptr;
+        $!ptr = Pointer;
+    }
+}

--- a/t/overload.t
+++ b/t/overload.t
@@ -28,11 +28,11 @@ $p5.run: q:heredoc/PERL5/;
 
 my $foo = $p5.invoke('Foo', 'new', 'a string!');
 is("$foo", 'a string!');
-unlike("$foo", /Perl5Object\<\d+\>/);
+unlike("$foo", /"Inline::Perl5::Object"\<\d+\>/);
 
 my $bar = $p5.invoke('Bar', 'new', 'a string!');
 isnt("$bar", 'a string!');
-like("$bar", /Perl5Object\<\-?\d+\>/);
+like("$bar", /"Inline::Perl5::Object"\<\-?\d+\>/);
 
 done-testing;
 


### PR DESCRIPTION
I can't remember if we discussed this before -- this extracts out the bindings to the interpreter into a separate file and switches to object-invocations. The general idea is to limit the scope of these things so its easy to reason about them. What I don't remember is if using the object-invocation syntax makes it slower or something.

I also pulled out Inline::Language::ObjectKeeper, which eventually I'd pull into a separate repo that other language bindings can use.

I figured that a good way to discuss would be to have a PR to be discussed :)
