### PR TITLE
Fix access to $=finish via CALLER pseudo

### DIFF
--- a/lib/Inline/Perl5.pm6
+++ b/lib/Inline/Perl5.pm6
@@ -1401,9 +1401,7 @@ method initialize(Bool :$reinitialize) {
 
     if ($*W) {
         my $block := {
-            my $ps := PseudoStash.new; # Can't just use CALLER:: due to rakudobug
-            self.init_data($ps.AT-KEY('CALLER').WHO.AT-KEY('$=finish'))
-                if $ps.AT-KEY('CALLER').WHO.AT-KEY('$=finish')
+            self.init_data($_) with CALLER::MY::<$=finish>;
         };
         $*W.add_object($block);
         my $op := $*W.add_phaser(Mu, 'ENTER', $block, class :: { method cuid { (^2**128).pick }});


### PR DESCRIPTION
`CALLER` is actually a dynamic chain only pseudo-package. The only reason `CALLER::<$=finish>` worked previously is due to a bug in underlying `PseudoStash`. Correct access must be done via `CALLER::MY::<$=finish>`.

It is also not necessary to workaround a bug in Rakudo by manually instantiating a `PseudoStash` instance. The above used `CALLER::MY::` syntax sugar works now.