### PR TITLE
Fix deprecation of $*PERL

### DIFF
--- a/lib/Inline/Perl5.pm6
+++ b/lib/Inline/Perl5.pm6
@@ -26,8 +26,8 @@ my $default_perl5;
 our $thread-safe = False;
 
 my constant $broken-rakudo = (
-    $*PERL.compiler.name eq 'rakudo'
-    and $*PERL.compiler.version before v2020.05.1.261.g.169.f.63.d.90
+    $*RAKU.compiler.name eq 'rakudo'
+    and $*RAKU.compiler.version before v2020.05.1.261.g.169.f.63.d.90
 );
 
 # I'd like to call this from Inline::Perl5::Interpreter


### PR DESCRIPTION
Although you might just want to make sure that the deprecation is not noted if you want to support versions of Raku before there was a $*RAKU  :-)