### PR TITLE
Fix an MRO-related exception

### DIFF
--- a/lib/Inline/Perl5/ClassHOW.pm6
+++ b/lib/Inline/Perl5/ClassHOW.pm6
@@ -237,10 +237,12 @@ class Inline::Perl5::ClassHOW
         nqp::bindattr(self, $?CLASS, '%!mro', nqp::hash(
             'all', nqp::hash(
                 'all',      $mro,
+                'all_conc', $mro,
                 'no_roles', $mro,
             ),
             'unhidden' , nqp::hash(
                 'all',      $mro,
+                'all_conc', $mro,
                 'no_roles', $mro,
             ),
         )) if '%!mro' (elem) $?CLASS.^attributes>>.name;


### PR DESCRIPTION
Perl6::Metamodel::C3MRO `%!mro` attribute got additional 'all_conc' key under both top-level keys.