### PR TITLE
Allow for existence of POPULATE method as well

### DIFF
--- a/lib/Inline/Perl5/ClassHOW.pm6
+++ b/lib/Inline/Perl5/ClassHOW.pm6
@@ -281,8 +281,9 @@ class Inline::Perl5::ClassHOW
             }
         }
         else {
-            for <BUILDALL bless can defined isa sink WHICH WHERE WHY ACCEPTS> {
-                %!cache{$_} := Mu.^method_table{$_};
+            for <BUILDALL bless can defined isa sink WHICH WHERE WHY ACCEPTS POPULATE> {
+                %!cache{$_} := Mu.^method_table{$_}
+                  if Mu.^method_table{$_}:exists;
             }
         }
 


### PR DESCRIPTION
As Fritz Zaucker showed in

  https://gist.github.com/zaucker/5800adb925e3836259387a00f5a717bc

Inline::Perl5 would segfault on a simple method call, which was traced back to the introduction of POPULATE in

  https://github.com/rakudo/rakudo/commit/ea1831c79f

This commit adds POPULATE to the list of expected methods in Mu, and conditionally puts it in the cache if it exists (which also applies to the other methods mentioned in that list, which shouldn't be an issue).  And thus fixes the golfed segfault code.

Tested both on pre-POPULATE rakudo, as well as post 2025.03 main.